### PR TITLE
Cambios ab2

### DIFF
--- a/src/module-info.java
+++ b/src/module-info.java
@@ -2,4 +2,5 @@ module arbolBinario {
 	exports tp02.ejercicio2;
 	exports tp03.ejercicio1.utils;
 	exports tp03.ejercicio1;
+	requires junit;
 }

--- a/src/tests/ArbolBinarioTestCase.java
+++ b/src/tests/ArbolBinarioTestCase.java
@@ -1,9 +1,5 @@
 package tests;
 
-
-
-
-
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
@@ -53,9 +49,6 @@ public class ArbolBinarioTestCase {
 		 *    10              8
 		 * 
 		 * */
-		
-		
-		
 	}
 
 	@Test
@@ -76,6 +69,13 @@ public class ArbolBinarioTestCase {
 	}
 	
 	@Test
+	public void testRecorridoPreorderVacio() {
+		ListaGenerica<Integer> lista_esperada = new ListaEnlazadaGenerica<>();
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<>();
+		assertEquals(lista_esperada, arbol_examples.preorder(new ArbolBinario<>()));
+	}
+	
+	@Test
 	public void testRecorridoInorder() {
 		ListaGenerica<Integer> lista_esperada = new ListaEnlazadaGenerica<Integer>();
 		lista_esperada.agregarFinal(1);
@@ -93,6 +93,13 @@ public class ArbolBinarioTestCase {
 	}
 	
 	@Test
+	public void testRecorridoInorderVacio() {
+		ListaGenerica<Integer> lista_esperada = new ListaEnlazadaGenerica<>();
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<>();
+		assertEquals(lista_esperada, arbol_examples.porNiveles(new ArbolBinario<>()));
+	}
+	
+	@Test
 	public void testRecorridoPostorder() {
 		ListaGenerica<Integer> lista_esperada = new ListaEnlazadaGenerica<Integer>();
 		lista_esperada.agregarFinal(10);
@@ -107,6 +114,12 @@ public class ArbolBinarioTestCase {
 		
 		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<Integer>();
 		assertEquals(lista_esperada, arbol_examples.postorder(this.ab));
+	}
+
+	@Test
+	public void testRecorridoPostorderVacio() {
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<>();
+		assertEquals(new ListaEnlazadaGenerica<Integer>(), arbol_examples.postorder(new ArbolBinario<Integer>()));
 	}
 	
 	@Test
@@ -127,9 +140,26 @@ public class ArbolBinarioTestCase {
 	}
 	
 	@Test
+	public void testRecorridoPorNivelesVacio() {
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<Integer>();
+		assertEquals(new ListaEnlazadaGenerica<Integer>(), arbol_examples.porNiveles(new ArbolBinario<>()));
+	}
+	
+	@Test
 	public void testContarHojas() {
 		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<Integer>();
 		assertEquals(4, arbol_examples.contarHojas(this.ab));
-		
+	}
+
+	@Test
+	public void testContarHojasVacio() {
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<>();
+		assertEquals(0, arbol_examples.contarHojas(new ArbolBinario<>()));
+	}
+	
+	@Test
+	public void testContarHojasHoja() {
+		ArbolBinarioExamples<Integer> arbol_examples = new ArbolBinarioExamples<>();
+		assertEquals(1, arbol_examples.contarHojas(new ArbolBinario<>(1)));
 	}
 }

--- a/src/tp03/ejercicio1/ArbolBinario.java
+++ b/src/tp03/ejercicio1/ArbolBinario.java
@@ -6,10 +6,17 @@ import tp02.ejercicio2.ListaGenerica;
 public class ArbolBinario<T> {
 	private T dato;
 	private ArbolBinario<T> hijoIzquierdo;   
-	private ArbolBinario<T> hijoDerecho; 
+	private ArbolBinario<T> hijoDerecho;
 	
 	/**
-	 *  Crea un árbol vacío
+	 * Para dejar en claro que el constructor sin parámetros crea arboles vacíos.
+	 */
+	public static <A> ArbolBinario<A> arbolVacio(){
+		return new ArbolBinario<>();
+	}
+	
+	/**
+	 *  Crea un árbol vacío.
 	 */
 	public ArbolBinario() {
 	}
@@ -18,7 +25,16 @@ public class ArbolBinario<T> {
 	 * Crea un árbol con un dato.  Si este es nulo, se lo considera vacío.
 	 */
 	public ArbolBinario(T dato) {
+		this(dato, null, null);
+	}
+	
+	/**
+	 * Crea un árbol con un dato y dos hijos.
+	 */
+	public ArbolBinario(T dato, ArbolBinario<T> hi, ArbolBinario<T> hd) {
 		this.dato = dato;
+		this.agregarHijoIzquierdo(hi);
+		this.agregarHijoDerecho(hd);
 	}
 
 	/*
@@ -34,33 +50,37 @@ public class ArbolBinario<T> {
 	}
 	
 	public ArbolBinario<T> getHijoIzquierdo() {
-		return this.hijoIzquierdo == null && !this.esVacio() ? new ArbolBinario<>() : this.hijoIzquierdo;
+		return this.hijoIzquierdo;
 	}
 
 	public ArbolBinario<T> getHijoDerecho() {
-		return this.hijoDerecho == null && !this.esVacio() ? new ArbolBinario<>() : this.hijoDerecho;
+		return this.hijoDerecho;
 	}
 
 	public void agregarHijoIzquierdo(ArbolBinario<T> hijo) {
-		this.hijoIzquierdo = hijo;
+		this.hijoIzquierdo = hijo == null ? arbolVacio() : hijo;
 	}
 
 	public void agregarHijoDerecho(ArbolBinario<T> hijo) {
-		this.hijoDerecho = hijo;
+		this.hijoDerecho = hijo == null ? arbolVacio() : hijo;
 	}
 
 	public void eliminarHijoIzquierdo() {
-		this.hijoIzquierdo = null;
+		this.hijoIzquierdo = arbolVacio();
 	}
 
 	public void eliminarHijoDerecho() {
-		this.hijoDerecho = null;
+		this.hijoDerecho = arbolVacio();
 	}
 
 	public boolean esVacio() {
-		return this.getDato() == null && !this.tieneHijoIzquierdo() && !this.tieneHijoDerecho();
+		// alcanza con que cualquiera sea nulo.
+		return this.hijoDerecho == null && this.hijoIzquierdo == null;
 	}
 
+	/**
+	 * Retorna si es una hoja.  Esta operación falla para árboles vacíos.
+	 */
 	public boolean esHoja() {
 		return !this.tieneHijoIzquierdo() && !this.tieneHijoDerecho();
 	}
@@ -69,13 +89,19 @@ public class ArbolBinario<T> {
 	public String toString() {
 		return this.getDato().toString();
 	}
-	 
+	
+	/**
+	 * Indica si tiene un hijo del lado izquierdo.  Esta operación no está definida para árboles vacíos.
+	 */
 	public boolean tieneHijoIzquierdo() {
-		return this.hijoIzquierdo!=null;
+		return !this.hijoIzquierdo.esVacio();
 	}
-	 
+	
+	/**
+	 * Indica si tiene un hijo del lado izquierdo.  Esta operación no está definida para árboles vacíos.
+	 */
 	public boolean tieneHijoDerecho() {
-		return this.hijoDerecho!=null;
+		return !this.hijoDerecho.esVacio();
 	}
 
 	public boolean esLleno() {

--- a/src/tp03/ejercicio1/ArbolBinario.java
+++ b/src/tp03/ejercicio1/ArbolBinario.java
@@ -7,12 +7,16 @@ public class ArbolBinario<T> {
 	private T dato;
 	private ArbolBinario<T> hijoIzquierdo;   
 	private ArbolBinario<T> hijoDerecho; 
-
 	
+	/**
+	 *  Crea un árbol vacío
+	 */
 	public ArbolBinario() {
-		super();
 	}
 
+	/**
+	 * Crea un árbol con un dato.  Si este es nulo, se lo considera vacío.
+	 */
 	public ArbolBinario(T dato) {
 		this.dato = dato;
 	}
@@ -29,17 +33,12 @@ public class ArbolBinario<T> {
 		this.dato = dato;
 	}
 	
-	/**
-	 * Preguntar antes de invocar si tieneHijoIzquierdo()
-	 * @return
-	 */
 	public ArbolBinario<T> getHijoIzquierdo() {
-		return this.hijoIzquierdo;
+		return this.hijoIzquierdo == null && !this.esVacio() ? new ArbolBinario<>() : this.hijoIzquierdo;
 	}
 
 	public ArbolBinario<T> getHijoDerecho() {
-		return this.hijoDerecho;
-
+		return this.hijoDerecho == null && !this.esVacio() ? new ArbolBinario<>() : this.hijoDerecho;
 	}
 
 	public void agregarHijoIzquierdo(ArbolBinario<T> hijo) {
@@ -63,26 +62,21 @@ public class ArbolBinario<T> {
 	}
 
 	public boolean esHoja() {
-		return (!this.tieneHijoIzquierdo() && !this.tieneHijoDerecho());
-
+		return !this.tieneHijoIzquierdo() && !this.tieneHijoDerecho();
 	}
 
 	@Override
 	public String toString() {
 		return this.getDato().toString();
 	}
-
 	 
 	public boolean tieneHijoIzquierdo() {
 		return this.hijoIzquierdo!=null;
 	}
-
 	 
 	public boolean tieneHijoDerecho() {
 		return this.hijoDerecho!=null;
 	}
-
-	
 
 	public boolean esLleno() {
 		return false;
@@ -91,38 +85,28 @@ public class ArbolBinario<T> {
 	 boolean esCompleto() {
 		return false;
 	}
-
 	
 	// imprime el árbol en preorden  
 	public void printPreorden() {
 		
 	}
 
-	// imprime el �rbol en postorden
+	// imprime el árbol en postorden
 	public void printPostorden() {
 		
 	}
 
-
 	public void recorridoPorNiveles() {
 		
 	}
-
-	
 
 	public ListaGenerica<T> frontera() {
 		ListaGenerica<T> l = new ListaEnlazadaGenerica<T>();
 
 		return l;
 	}
-
-	
-	
 	
 	public int contarHojas() {
 		return 0;
 	}
-
-	
-
 }

--- a/src/tp03/ejercicio1/utils/ArbolBinarioExamples.java
+++ b/src/tp03/ejercicio1/utils/ArbolBinarioExamples.java
@@ -6,115 +6,81 @@ import tp03.ejercicio1.ArbolBinario;
 
 public class ArbolBinarioExamples<T> {
 	
-	
-	
 	public ListaGenerica<T> preorder(ArbolBinario<T> arbol){
 		ListaGenerica<T> result = new ListaEnlazadaGenerica<T>();
 		this.preorder_private(arbol, result);
 		return result;
-			
-		}
+	}
 	
 	private void preorder_private(ArbolBinario<T> arbol, ListaGenerica<T> result) {
-		if (!arbol.esVacio()){
+		if (!arbol.esVacio()) {
 			result.agregarFinal(arbol.getDato());
-		}
-		if (arbol.tieneHijoIzquierdo()){
 			this.preorder_private(arbol.getHijoIzquierdo(), result);
-		}
-		if (arbol.tieneHijoDerecho()) {
 			this.preorder_private(arbol.getHijoDerecho(), result);
 		}
-		
 	}
 	
 	public ListaGenerica<T> inorder(ArbolBinario<T> arbol){
 		ListaGenerica<T> result = new ListaEnlazadaGenerica<T>();
 		this.inorder_private(arbol, result);
 		return result;
-			
-		}
+	}
 	
 	private void inorder_private(ArbolBinario<T> arbol, ListaGenerica<T> result) {
-		
-		if (arbol.tieneHijoIzquierdo()){
+		if (!arbol.esVacio()) {
 			this.inorder_private(arbol.getHijoIzquierdo(), result);
-		}
-		if (!arbol.esVacio()){
 			result.agregarFinal(arbol.getDato());
-		}
-		if (arbol.tieneHijoDerecho()) {
 			this.inorder_private(arbol.getHijoDerecho(), result);
 		}
-		
 	}
 	
 	public ListaGenerica<T> postorder(ArbolBinario<T> arbol){
 		ListaGenerica<T> result = new ListaEnlazadaGenerica<T>();
 		this.postorder_private(arbol, result);
 		return result;
-			
-		}
+	}
 	
     private void postorder_private(ArbolBinario<T> arbol, ListaGenerica<T> result) {
-		
-		if (arbol.tieneHijoIzquierdo()){
+    	if (!arbol.esVacio()){
 			this.postorder_private(arbol.getHijoIzquierdo(), result);
-		}
-		
-		if (arbol.tieneHijoDerecho()) {
 			this.postorder_private(arbol.getHijoDerecho(), result);
-		}
-		
-		if (!arbol.esVacio()){
 			result.agregarFinal(arbol.getDato());
-		}
-		
+    	}
 	}
     
     public ListaGenerica<T> porNiveles(ArbolBinario<T> arbol){
     	ListaGenerica<T> result = new ListaEnlazadaGenerica<T>();
-    	ListaGenerica<ArbolBinario<T>> cola = new ListaEnlazadaGenerica<ArbolBinario<T>>();
-    	ArbolBinario<T> arbol_encolado;
     	
-    	cola.agregarFinal(arbol);
-    	cola.agregarFinal(null);
-    	
-    	while(cola.tamanio()>0) {
-    		arbol_encolado = cola.elemento(1);
-    		cola.eliminarEn(1);
-    		
-    		if (arbol_encolado!=null) {
-    			result.agregarFinal(arbol_encolado.getDato());
-    			if (arbol_encolado.tieneHijoIzquierdo())
-    				cola.agregarFinal(arbol_encolado.getHijoIzquierdo());
-    			if (arbol_encolado.tieneHijoDerecho())
-    				cola.agregarFinal(arbol_encolado.getHijoDerecho());
-    			
-    		}else {
-    			if (cola.tamanio()>0)
-    				cola.agregarFinal(null);
-    		}
-    		
+    	if (!arbol.esVacio()) {
+	    	ListaGenerica<ArbolBinario<T>> cola = new ListaEnlazadaGenerica<ArbolBinario<T>>();
+	    	ArbolBinario<T> arbol_encolado;
+	    	
+	    	cola.agregarFinal(arbol);
+	   		while(!cola.esVacia()) {
+	    		arbol_encolado = cola.elemento(1);
+	    		cola.eliminarEn(1);
+				result.agregarFinal(arbol_encolado.getDato());
+				if (arbol_encolado.tieneHijoIzquierdo())
+					cola.agregarFinal(arbol_encolado.getHijoIzquierdo());
+				if (arbol_encolado.tieneHijoDerecho())
+					cola.agregarFinal(arbol_encolado.getHijoDerecho());
+	    	}
     	}
-    	
     	return result;
     }
+
     public int contarHojas(ArbolBinario<T> arbol) {
     	int hojas = 0;
-    	if (arbol.esHoja()) {
-    		hojas++;
-    	}else {
-    		if (arbol.tieneHijoIzquierdo()) {
+    	if (!arbol.esVacio()) {
+	    	if (arbol.esHoja()) {
+	    		hojas++;
+	    	}
+	    	else {
     			hojas = hojas + this.contarHojas(arbol.getHijoIzquierdo());
-    		}
-    		if (arbol.tieneHijoDerecho()) {
     			hojas = hojas + this.contarHojas(arbol.getHijoDerecho());
-    		}
+	    	}
     	}
     	return hojas;
     }
 }
-	
-
 


### PR DESCRIPTION
Mejor versión sobre el pull request anterior (que podés desestimar).
En esta, los árboles no vacíos tienen siempre una instancia como hijos, sacando así los chequeos por null.

También se deja de verificar la condición de vacío a partir de que tenga o no un valor nulo como dato (o sea, la colección permite guardar valores nulos).